### PR TITLE
Req 2 cancel bookings

### DIFF
--- a/composeApp/src/androidMain/kotlin/at/rent4u/navigation/Navigation.kt
+++ b/composeApp/src/androidMain/kotlin/at/rent4u/navigation/Navigation.kt
@@ -1,5 +1,7 @@
 package at.rent4u.navigation
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
@@ -14,9 +16,11 @@ import at.rent4u.screens.ToolListScreen
 import at.rent4u.screens.BookingScreen
 import at.rent4u.screens.AdminToolEditorScreen
 import at.rent4u.screens.LoginScreen
+import at.rent4u.screens.MyBookingsScreen
 import at.rent4u.screens.ProfileScreen
 import at.rent4u.screens.RegisterScreen
 
+@RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun Rent4uNavGraph(navController: NavHostController = rememberNavController()) {
     NavHost(navController = navController, startDestination = Screen.Login.route) {
@@ -39,6 +43,10 @@ fun Rent4uNavGraph(navController: NavHostController = rememberNavController()) {
         ) { backStackEntry ->
             val toolId = backStackEntry.arguments?.getString(ARG_TOOL_ID) ?: ""
             BookingScreen(toolId = toolId, navController = navController)
+        }
+
+        composable(Screen.MyBookings.route) {
+            MyBookingsScreen(navController)
         }
 
         composable(Screen.AdminToolEditor.route) {

--- a/composeApp/src/androidMain/kotlin/at/rent4u/presentation/MyBookingsViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/at/rent4u/presentation/MyBookingsViewModel.kt
@@ -30,17 +30,22 @@ class MyBookingsViewModel @Inject constructor(
     private val _toastMessage = MutableStateFlow<String?>(null)
     val toastMessage: StateFlow<String?> = _toastMessage
 
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading
+
     @RequiresApi(Build.VERSION_CODES.O)
     fun fetchUserBookings() {
         val userId = userRepository.getCurrentUserId() ?: return
 
         viewModelScope.launch {
+            _isLoading.value = true
             val bookings = repository.getBookingsForUser(userId)
             _userBookings.value = bookings
 
             val toolIds = bookings.map { it.toolId }.toSet()
             val tools = repository.getToolsByIds(toolIds)
-            _bookedTools.value = tools.associate { it.first to it.second }  // toolId -> Tool
+            _bookedTools.value = tools.associate { it.first to it.second } // toolId -> Tool
+            _isLoading.value = false
         }
     }
 

--- a/composeApp/src/androidMain/kotlin/at/rent4u/presentation/MyBookingsViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/at/rent4u/presentation/MyBookingsViewModel.kt
@@ -12,6 +12,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import java.time.LocalDate
 import javax.inject.Inject
 
 @HiltViewModel
@@ -25,6 +26,9 @@ class MyBookingsViewModel @Inject constructor(
 
     private val _bookedTools = MutableStateFlow<Map<String, Tool>>(emptyMap())
     val bookedTools: StateFlow<Map<String, Tool>> = _bookedTools
+
+    private val _toastMessage = MutableStateFlow<String?>(null)
+    val toastMessage: StateFlow<String?> = _toastMessage
 
     @RequiresApi(Build.VERSION_CODES.O)
     fun fetchUserBookings() {
@@ -43,8 +47,19 @@ class MyBookingsViewModel @Inject constructor(
     @RequiresApi(Build.VERSION_CODES.O)
     fun cancelBooking(booking: Booking) {
         viewModelScope.launch {
+            val startDate = LocalDate.parse(booking.startDate)
+            if (startDate.isBefore(LocalDate.now().plusDays(2))) {
+                _toastMessage.value = "You can only cancel bookings at least 48 hours in advance"
+                return@launch
+            }
+
             repository.cancelBooking(booking)
+            _toastMessage.value = "Booking canceled successfully"
             fetchUserBookings()
         }
+    }
+
+    fun clearToastMessage() {
+        _toastMessage.value = null
     }
 }

--- a/composeApp/src/androidMain/kotlin/at/rent4u/presentation/MyBookingsViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/at/rent4u/presentation/MyBookingsViewModel.kt
@@ -1,0 +1,50 @@
+package at.rent4u.presentation
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import at.rent4u.data.ToolRepository
+import at.rent4u.data.UserRepository
+import at.rent4u.model.Booking
+import at.rent4u.model.Tool
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MyBookingsViewModel @Inject constructor(
+    private val repository: ToolRepository,
+    private val userRepository: UserRepository
+) : ViewModel() {
+
+    private val _userBookings = MutableStateFlow<List<Booking>>(emptyList())
+    val userBookings: StateFlow<List<Booking>> = _userBookings
+
+    private val _bookedTools = MutableStateFlow<Map<String, Tool>>(emptyMap())
+    val bookedTools: StateFlow<Map<String, Tool>> = _bookedTools
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    fun fetchUserBookings() {
+        val userId = userRepository.getCurrentUserId() ?: return
+
+        viewModelScope.launch {
+            val bookings = repository.getBookingsForUser(userId)
+            _userBookings.value = bookings
+
+            val toolIds = bookings.map { it.toolId }.toSet()
+            val tools = repository.getToolsByIds(toolIds)
+            _bookedTools.value = tools.associate { it.first to it.second }  // toolId -> Tool
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    fun cancelBooking(booking: Booking) {
+        viewModelScope.launch {
+            repository.cancelBooking(booking)
+            fetchUserBookings()
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/at/rent4u/screens/BookingScreen.kt
+++ b/composeApp/src/androidMain/kotlin/at/rent4u/screens/BookingScreen.kt
@@ -148,8 +148,7 @@ fun CustomCalendarPicker(
         val lastDay = currentMonth.lengthOfMonth()
         val firstDayOfWeek = firstDayOfMonth.dayOfWeek.value % 7 // Sunday = 0
 
-        val totalGridCells = ((firstDayOfWeek + lastDay + 6) / 7) * 7
-        (0 until totalGridCells).map { index ->
+        (0 until ((firstDayOfWeek + lastDay + 6) / 7) * 7).map { index ->
             val dayOffset = index - firstDayOfWeek
             if (dayOffset in 0 until lastDay) currentMonth.atDay(dayOffset + 1) else null
         }
@@ -189,6 +188,7 @@ fun CustomCalendarPicker(
             modifier = Modifier.height(300.dp).padding(8.dp)
         ) {
             itemsIndexed(days) { _, date ->
+                val isPast = date != null && date.isBefore(LocalDate.now())
                 val isBooked = date != null && bookedDates.contains(date)
                 val isSelected = date != null && (date == startDate || date == endDate ||
                         (startDate != null && endDate != null &&
@@ -200,12 +200,12 @@ fun CustomCalendarPicker(
                         .padding(2.dp)
                         .background(
                             when {
-                                isBooked -> Color.LightGray
+                                isBooked || isPast -> Color.LightGray
                                 isSelected -> MaterialTheme.colorScheme.primary
                                 else -> Color.Transparent
                             }
                         )
-                        .clickable(enabled = date != null && !isBooked) {
+                        .clickable(enabled = date != null && !isBooked && !isPast) {
                             date?.let {
                                 if (startDate == null || (startDate != null && endDate != null)) {
                                     startDate = it

--- a/composeApp/src/androidMain/kotlin/at/rent4u/screens/BookingScreen.kt
+++ b/composeApp/src/androidMain/kotlin/at/rent4u/screens/BookingScreen.kt
@@ -90,8 +90,9 @@ fun BookingScreen(
                 .verticalScroll(rememberScrollState())
         ) {
             tool?.let {
-                LabelInputPair("Name", it.type)
+                LabelInputPair("Brand", it.brand)
                 LabelInputPair("Model", it.modelNumber)
+                LabelInputPair("Type", it.type)
                 LabelInputPair("Rental Rate", "${it.rentalRate}€")
             }
 

--- a/composeApp/src/androidMain/kotlin/at/rent4u/screens/MyBookingsScreen.kt
+++ b/composeApp/src/androidMain/kotlin/at/rent4u/screens/MyBookingsScreen.kt
@@ -3,6 +3,7 @@ package at.rent4u.screens
 import android.os.Build
 import android.widget.Toast
 import androidx.annotation.RequiresApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -10,6 +11,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
@@ -19,6 +21,7 @@ import androidx.navigation.NavController
 import at.rent4u.model.Booking
 import at.rent4u.presentation.MyBookingsViewModel
 import coil.compose.AsyncImage
+import java.time.LocalDate
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
@@ -49,49 +52,79 @@ fun MyBookingsScreen(
             Text("My Bookings", style = MaterialTheme.typography.headlineMedium)
             Spacer(modifier = Modifier.height(16.dp))
 
-            LazyColumn {
-                items(bookings.value) { booking ->
-                    val tool = tools.value[booking.toolId]
-                    if (tool != null) {
-                        Card(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 8.dp),
-                            elevation = CardDefaults.cardElevation(4.dp)
-                        ) {
-                            Row(modifier = Modifier.padding(16.dp)) {
-                                AsyncImage(
-                                    model = tool.image,
-                                    contentDescription = "Tool Image",
-                                    modifier = Modifier
-                                        .size(120.dp)
-                                        .clip(RoundedCornerShape(8.dp))
-                                        .clickable {
-                                            navController.navigate(Screen.ToolDetails.createRoute(booking.toolId))
-                                        }
-                                )
+            // only show active bookings, not the ones from the past
+            val activeBookings = bookings.value.filter {
+                val endDate = LocalDate.parse(it.endDate)
+                !endDate.isBefore(LocalDate.now())
+            }
 
-                                Spacer(modifier = Modifier.width(16.dp))
-
-                                Column(modifier = Modifier.weight(1f)) {
-                                    Text(text = "${tool.type} (${tool.brand})", style = MaterialTheme.typography.titleMedium)
-                                    Text(text = "Model: ${tool.modelNumber}")
-                                    Text(text = "Rental: ${tool.rentalRate}")
-                                    Text(
-                                        text = "From: ${booking.startDate} To: ${booking.endDate}",
-                                        style = MaterialTheme.typography.bodySmall
+            if (activeBookings.isEmpty()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(24.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant)
+                        .padding(24.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = "You currently have no active bookings. Book a tool to get started!",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Spacer(modifier = Modifier.height(12.dp))
+                        Button(onClick = { navController.navigate(Screen.ToolList.route) }) {
+                            Text("Browse Tools")
+                        }
+                    }
+                }
+            } else {
+                LazyColumn {
+                    items(activeBookings) { booking ->
+                        val tool = tools.value[booking.toolId]
+                        if (tool != null) {
+                            Card(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 8.dp),
+                                elevation = CardDefaults.cardElevation(4.dp)
+                            ) {
+                                Row(modifier = Modifier.padding(16.dp)) {
+                                    AsyncImage(
+                                        model = tool.image,
+                                        contentDescription = "Tool Image",
+                                        modifier = Modifier
+                                            .size(120.dp)
+                                            .clip(RoundedCornerShape(8.dp))
+                                            .clickable {
+                                                navController.navigate(Screen.ToolDetails.createRoute(booking.toolId))
+                                            }
                                     )
 
-                                    Spacer(modifier = Modifier.height(8.dp))
+                                    Spacer(modifier = Modifier.width(16.dp))
 
-                                    Button(
-                                        onClick = { bookingToCancel = booking },
-                                        colors = ButtonDefaults.buttonColors(
-                                            containerColor = MaterialTheme.colorScheme.error,
-                                            contentColor = MaterialTheme.colorScheme.onError
+                                    Column(modifier = Modifier.weight(1f)) {
+                                        Text(text = "${tool.type} (${tool.brand})", style = MaterialTheme.typography.titleMedium)
+                                        Text(text = "Model: ${tool.modelNumber}")
+                                        Text(text = "Rental: ${tool.rentalRate}")
+                                        Text(
+                                            text = "From: ${booking.startDate} To: ${booking.endDate}",
+                                            style = MaterialTheme.typography.bodySmall
                                         )
-                                    ) {
-                                        Text("Cancel Booking")
+
+                                        Spacer(modifier = Modifier.height(8.dp))
+
+                                        Button(
+                                            onClick = { bookingToCancel = booking },
+                                            colors = ButtonDefaults.buttonColors(
+                                                containerColor = MaterialTheme.colorScheme.error,
+                                                contentColor = MaterialTheme.colorScheme.onError
+                                            )
+                                        ) {
+                                            Text("Cancel Booking")
+                                        }
                                     }
                                 }
                             }

--- a/composeApp/src/androidMain/kotlin/at/rent4u/screens/MyBookingsScreen.kt
+++ b/composeApp/src/androidMain/kotlin/at/rent4u/screens/MyBookingsScreen.kt
@@ -1,0 +1,91 @@
+package at.rent4u.screens
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import at.rent4u.presentation.MyBookingsViewModel
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+fun MyBookingsScreen(
+    navController: NavController,
+    viewModel: MyBookingsViewModel = hiltViewModel()
+) {
+    val bookings = viewModel.userBookings.collectAsState()
+    val tools = viewModel.bookedTools.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.fetchUserBookings()
+    }
+
+    Scaffold(
+        bottomBar = { BottomNavBar(navController) }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .padding(16.dp)
+        ) {
+            Text("My Bookings", style = MaterialTheme.typography.headlineMedium)
+            Spacer(modifier = Modifier.height(16.dp))
+
+            LazyColumn {
+                items(bookings.value) { booking ->
+                    val tool = tools.value[booking.toolId]
+                    if (tool != null) {
+                        Card(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 8.dp),
+                            elevation = CardDefaults.cardElevation(4.dp)
+                        ) {
+                            Column(modifier = Modifier.padding(16.dp)) {
+                                Text(text = "${tool.type} (${tool.brand})", style = MaterialTheme.typography.titleMedium)
+                                Text(text = "Model: ${tool.modelNumber}")
+                                Text(text = "Rental: ${tool.rentalRate}")
+                                Text(
+                                    text = "From: ${booking.startDate} To: ${booking.endDate}",
+                                    style = MaterialTheme.typography.bodySmall
+                                )
+
+                                Spacer(modifier = Modifier.height(8.dp))
+
+                                Button(
+                                    onClick = { viewModel.cancelBooking(booking) },
+                                    colors = ButtonDefaults.buttonColors(
+                                        containerColor = MaterialTheme.colorScheme.error,
+                                        contentColor = MaterialTheme.colorScheme.onError
+                                    )
+                                ) {
+                                    Text("Cancel Booking")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/at/rent4u/screens/MyBookingsScreen.kt
+++ b/composeApp/src/androidMain/kotlin/at/rent4u/screens/MyBookingsScreen.kt
@@ -2,29 +2,22 @@ package at.rent4u.screens
 
 import android.os.Build
 import androidx.annotation.RequiresApi
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import at.rent4u.presentation.MyBookingsViewModel
+import coil.compose.AsyncImage
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
@@ -61,25 +54,40 @@ fun MyBookingsScreen(
                                 .padding(vertical = 8.dp),
                             elevation = CardDefaults.cardElevation(4.dp)
                         ) {
-                            Column(modifier = Modifier.padding(16.dp)) {
-                                Text(text = "${tool.type} (${tool.brand})", style = MaterialTheme.typography.titleMedium)
-                                Text(text = "Model: ${tool.modelNumber}")
-                                Text(text = "Rental: ${tool.rentalRate}")
-                                Text(
-                                    text = "From: ${booking.startDate} To: ${booking.endDate}",
-                                    style = MaterialTheme.typography.bodySmall
+                            Row(modifier = Modifier.padding(16.dp)) {
+                                AsyncImage(
+                                    model = tool.image,
+                                    contentDescription = "Tool Image",
+                                    modifier = Modifier
+                                        .size(120.dp)
+                                        .clip(RoundedCornerShape(8.dp))
+                                        .clickable {
+                                            navController.navigate(Screen.ToolDetails.createRoute(booking.toolId))
+                                        }
                                 )
 
-                                Spacer(modifier = Modifier.height(8.dp))
+                                Spacer(modifier = Modifier.width(16.dp))
 
-                                Button(
-                                    onClick = { viewModel.cancelBooking(booking) },
-                                    colors = ButtonDefaults.buttonColors(
-                                        containerColor = MaterialTheme.colorScheme.error,
-                                        contentColor = MaterialTheme.colorScheme.onError
+                                Column(modifier = Modifier.weight(1f)) {
+                                    Text(text = "${tool.type} (${tool.brand})", style = MaterialTheme.typography.titleMedium)
+                                    Text(text = "Model: ${tool.modelNumber}")
+                                    Text(text = "Rental: ${tool.rentalRate}")
+                                    Text(
+                                        text = "From: ${booking.startDate} To: ${booking.endDate}",
+                                        style = MaterialTheme.typography.bodySmall
                                     )
-                                ) {
-                                    Text("Cancel Booking")
+
+                                    Spacer(modifier = Modifier.height(8.dp))
+
+                                    Button(
+                                        onClick = { viewModel.cancelBooking(booking) },
+                                        colors = ButtonDefaults.buttonColors(
+                                            containerColor = MaterialTheme.colorScheme.error,
+                                            contentColor = MaterialTheme.colorScheme.onError
+                                        )
+                                    ) {
+                                        Text("Cancel Booking")
+                                    }
                                 }
                             }
                         }

--- a/composeApp/src/androidMain/kotlin/at/rent4u/screens/MyBookingsScreen.kt
+++ b/composeApp/src/androidMain/kotlin/at/rent4u/screens/MyBookingsScreen.kt
@@ -8,14 +8,13 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
+import at.rent4u.model.Booking
 import at.rent4u.presentation.MyBookingsViewModel
 import coil.compose.AsyncImage
 
@@ -27,6 +26,7 @@ fun MyBookingsScreen(
 ) {
     val bookings = viewModel.userBookings.collectAsState()
     val tools = viewModel.bookedTools.collectAsState()
+    var bookingToCancel by remember { mutableStateOf<Booking?>(null) }
 
     LaunchedEffect(Unit) {
         viewModel.fetchUserBookings()
@@ -80,7 +80,7 @@ fun MyBookingsScreen(
                                     Spacer(modifier = Modifier.height(8.dp))
 
                                     Button(
-                                        onClick = { viewModel.cancelBooking(booking) },
+                                        onClick = { bookingToCancel = booking },
                                         colors = ButtonDefaults.buttonColors(
                                             containerColor = MaterialTheme.colorScheme.error,
                                             contentColor = MaterialTheme.colorScheme.onError
@@ -94,6 +94,27 @@ fun MyBookingsScreen(
                     }
                 }
             }
+        }
+
+        bookingToCancel?.let { booking ->
+            AlertDialog(
+                onDismissRequest = { bookingToCancel = null },
+                title = { Text("Confirm Cancellation") },
+                text = { Text("Are you sure you want to cancel this booking?") },
+                confirmButton = {
+                    TextButton(onClick = {
+                        viewModel.cancelBooking(booking)
+                        bookingToCancel = null
+                    }) {
+                        Text("Yes")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { bookingToCancel = null }) {
+                        Text("No")
+                    }
+                }
+            )
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/at/rent4u/screens/MyBookingsScreen.kt
+++ b/composeApp/src/androidMain/kotlin/at/rent4u/screens/MyBookingsScreen.kt
@@ -1,6 +1,7 @@
 package at.rent4u.screens
 
 import android.os.Build
+import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -11,6 +12,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
@@ -27,6 +29,9 @@ fun MyBookingsScreen(
     val bookings = viewModel.userBookings.collectAsState()
     val tools = viewModel.bookedTools.collectAsState()
     var bookingToCancel by remember { mutableStateOf<Booking?>(null) }
+
+    val context = LocalContext.current
+    val toastMessage by viewModel.toastMessage.collectAsState()
 
     LaunchedEffect(Unit) {
         viewModel.fetchUserBookings()
@@ -93,6 +98,11 @@ fun MyBookingsScreen(
                         }
                     }
                 }
+            }
+
+            toastMessage?.let {
+                Toast.makeText(context, it, Toast.LENGTH_LONG).show()
+                viewModel.clearToastMessage()
             }
         }
 

--- a/composeApp/src/androidMain/kotlin/at/rent4u/screens/MyBookingsScreen.kt
+++ b/composeApp/src/androidMain/kotlin/at/rent4u/screens/MyBookingsScreen.kt
@@ -36,6 +36,8 @@ fun MyBookingsScreen(
     val context = LocalContext.current
     val toastMessage by viewModel.toastMessage.collectAsState()
 
+    val isLoading by viewModel.isLoading.collectAsState()
+
     LaunchedEffect(Unit) {
         viewModel.fetchUserBookings()
     }
@@ -58,7 +60,14 @@ fun MyBookingsScreen(
                 !endDate.isBefore(LocalDate.now())
             }
 
-            if (activeBookings.isEmpty()) {
+            if (isLoading) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            } else if (activeBookings.isEmpty()) {
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()

--- a/composeApp/src/androidMain/kotlin/at/rent4u/screens/ProfileScreen.kt
+++ b/composeApp/src/androidMain/kotlin/at/rent4u/screens/ProfileScreen.kt
@@ -1,11 +1,15 @@
 package at.rent4u.screens
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -24,12 +28,32 @@ fun ProfileScreen(navController: NavController) {
     Scaffold(
         bottomBar = { BottomNavBar(navController) }
     ) {
-        Box(
+        Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(it),
-            contentAlignment = Alignment.BottomCenter
+            verticalArrangement = Arrangement.Top,
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            Spacer(modifier = Modifier.height(32.dp))
+
+            Button(
+                onClick = {
+                    navController.navigate(Screen.MyBookings.route)
+                },
+                modifier = Modifier
+                    .fillMaxWidth(0.9f)
+                    .padding(bottom = 16.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = Color.White
+                )
+            ) {
+                Text("My Bookings")
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
             Button(
                 onClick = {
                     viewModel.logout()

--- a/composeApp/src/androidMain/kotlin/at/rent4u/screens/Screen.kt
+++ b/composeApp/src/androidMain/kotlin/at/rent4u/screens/Screen.kt
@@ -14,4 +14,5 @@ sealed class Screen(val route: String) {
     object Login : Screen("login")
     object Profile : Screen("profile")
     object Register : Screen("register")
+    object MyBookings : Screen("my_bookings")
 }

--- a/composeApp/src/androidMain/kotlin/at/rent4u/screens/ToolDetailsScreen.kt
+++ b/composeApp/src/androidMain/kotlin/at/rent4u/screens/ToolDetailsScreen.kt
@@ -94,6 +94,7 @@ fun ToolDetailsScreen(
 
                     Spacer(modifier = Modifier.height(24.dp))
 
+                    LabelInputPair("Brand", tool.brand)
                     LabelInputPair("Model", tool.modelNumber)
                     LabelInputPair("Description", tool.description)
                     LabelInputPair("Availability", tool.availabilityStatus)

--- a/composeApp/src/androidMain/kotlin/at/rent4u/screens/ToolDetailsScreen.kt
+++ b/composeApp/src/androidMain/kotlin/at/rent4u/screens/ToolDetailsScreen.kt
@@ -108,20 +108,22 @@ fun ToolDetailsScreen(
 
                     Spacer(modifier = Modifier.height(16.dp))
 
-                    Button(
-                        onClick = {
-                            navController.navigate(Screen.Booking.createRoute(toolId))
-                        },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(50.dp),
-                        shape = RoundedCornerShape(24.dp),
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = Color.LightGray,
-                            contentColor = Color.Black
-                        )
-                    ) {
-                        Text("Book this Tool")
+                    if (tool.availabilityStatus == "Available") {
+                        Button(
+                            onClick = {
+                                navController.navigate(Screen.Booking.createRoute(toolId))
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(50.dp),
+                            shape = RoundedCornerShape(24.dp),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = Color.LightGray,
+                                contentColor = Color.Black
+                            )
+                        ) {
+                            Text("Book this Tool")
+                        }
                     }
 
                     Spacer(modifier = Modifier.height(80.dp))


### PR DESCRIPTION
Implemented:
* added new button in the user profile which can be used to navigate to his bookings
* added new screen my bookings which shows the current bookings without the passed ones
* the user can click on the tool image to go to the detail screen of the tool
* if no tools booked, a message is shown and a button to browse tools for booking
* the user is able to cancel his bookings by clicking a button. The button opens a dialog where the user has to confirm the action
* the user is only able to cancel bookings if >48h until the booking

- user profile - my bookings button
![image](https://github.com/user-attachments/assets/3d8e56d0-d326-44aa-8a5d-6014e278c912)

- my bookings screen - no bookings
![image](https://github.com/user-attachments/assets/acccb20a-a0a1-4a7b-9c8a-c3ee2717571b)

- my booking screen - bookings available
![image](https://github.com/user-attachments/assets/aff8e4de-8b43-4d15-a7c8-b2d990f8a11e)

- cancel booking
![image](https://github.com/user-attachments/assets/3361aa9f-0200-4bc5-a3f1-56e5479bf8ca)
